### PR TITLE
New grammar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,22 +19,29 @@ checksum = "414dcefbc63d77c526a76b3afcf6fbb9b5e2791c19c3aa2297733208750c6e53"
 
 [[package]]
 name = "bech32"
-version = "0.9.1"
+version = "0.10.0-beta"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+checksum = "98f7eed2b2781a6f0b5c903471d48e15f56fb4e1165df8a9a2337fd1a59d45ea"
 
 [[package]]
 name = "bitcoin"
-version = "0.30.1"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e99ff7289b20a7385f66a0feda78af2fc119d28fb56aea8886a9cd0a4abdd75"
+checksum = "fd00f3c09b5f21fb357abe32d29946eb8bb7a0862bae62c0b5e4a692acbbe73c"
 dependencies = [
  "bech32",
- "bitcoin-private",
- "bitcoin_hashes 0.12.0",
+ "bitcoin-internals",
+ "bitcoin_hashes 0.13.0",
+ "hex-conservative",
  "hex_lit",
  "secp256k1",
 ]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
 
 [[package]]
 name = "bitcoin-private"
@@ -44,17 +51,21 @@ checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
-
-[[package]]
-name = "bitcoin_hashes"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
 dependencies = [
  "bitcoin-private",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
+dependencies = [
+ "bitcoin-internals",
+ "hex-conservative",
 ]
 
 [[package]]
@@ -118,14 +129,13 @@ dependencies = [
 
 [[package]]
 name = "elements"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686e85412860d3ac25988e55da4d65541714f1318bf10fd81711e08cbfdcf5b4"
+checksum = "dd6b8388053196e6b2702a45418078a654680ce9e1fd91799f51f67a40118ff5"
 dependencies = [
  "bitcoin",
  "secp256k1-zkp",
  "serde_json",
- "slip21",
 ]
 
 [[package]]
@@ -187,12 +197,13 @@ checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "miniscript"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eb102b66b2127a872dbcc73095b7b47aeb9d92f7b03c2b2298253ffc82c7594"
+checksum = "86a23dd3ad145a980e231185d114399f25a0a307d2cd918010ddda6334323df9"
 dependencies = [
+ "bech32",
  "bitcoin",
- "bitcoin-private",
+ "bitcoin-internals",
 ]
 
 [[package]]
@@ -346,7 +357,7 @@ dependencies = [
  "pest_derive",
  "serde",
  "serde_json",
- "simplicity",
+ "simplicity-lang",
 ]
 
 [[package]]
@@ -360,9 +371,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.27.0"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
+checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
 dependencies = [
  "bitcoin_hashes 0.12.0",
  "rand",
@@ -371,18 +382,18 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.8.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
+checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "secp256k1-zkp"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "026efcdacb95ee6aae5cc19144dc1549973eac36a4972700c28493de1ee5d69f"
+checksum = "c4e48ef9c98bfbcb98bd15693ffa19676cb3e29426b75eda8b73c05cdd7959f8"
 dependencies = [
  "bitcoin-private",
  "rand",
@@ -392,9 +403,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-zkp-sys"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d03ab1ca75a18e1899e8d9b8d28b5998ae1ddcb42fec5956769718543293c723"
+checksum = "b4ead52f43074bae2ddbd1e0e66e6b170135e76117f5ea9916f33d7bd0b36e29"
 dependencies = [
  "cc",
  "secp256k1-sys",
@@ -443,12 +454,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "simplicity"
-version = "0.1.0"
-source = "git+https://github.com/BlockstreamResearch/rust-simplicity?rev=282ade747c50e6b8c97217791d9e930b7e56f73f#282ade747c50e6b8c97217791d9e930b7e56f73f"
+name = "simplicity-lang"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e55431814fcbfd27d48c5707655b10aa12314e004dcb3cd27c2a05550d64be3c"
 dependencies = [
  "bitcoin",
- "bitcoin_hashes 0.12.0",
+ "bitcoin_hashes 0.13.0",
  "byteorder",
  "elements",
  "hex-conservative",
@@ -459,21 +471,13 @@ dependencies = [
 
 [[package]]
 name = "simplicity-sys"
-version = "0.1.0"
-source = "git+https://github.com/BlockstreamResearch/rust-simplicity?rev=282ade747c50e6b8c97217791d9e930b7e56f73f#282ade747c50e6b8c97217791d9e930b7e56f73f"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a2882d81a2163e0753a6831fe6a07f1cf8d1bcfc833531ef44ef10bb6f099ed"
 dependencies = [
- "bitcoin_hashes 0.12.0",
+ "bitcoin_hashes 0.13.0",
  "cc",
  "libc",
-]
-
-[[package]]
-name = "slip21"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516f52f3cec67962a9c414130251b512f2ff47f81980411ae01b6ce540b1ca6b"
-dependencies = [
- "bitcoin_hashes 0.11.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,6 +353,7 @@ dependencies = [
  "base64",
  "hex-conservative",
  "lazy_static",
+ "miniscript",
  "pest",
  "pest_derive",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ pest_derive = "2.7.1"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.105"
 simplicity-lang = "0.2.0"
+miniscript = "11.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,4 @@ pest = "2.1.3"
 pest_derive = "2.7.1"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.105"
-
-simplicity = {git = "https://github.com/BlockstreamResearch/rust-simplicity", rev = "282ade747c50e6b8c97217791d9e930b7e56f73f"}
+simplicity-lang = "0.2.0"

--- a/example_progs/add.simpl
+++ b/example_progs/add.simpl
@@ -1,5 +1,5 @@
 let a : u32 = 2;
-let b : u32 = 3;
+let b : (u16, (u8, (u4, (u2, (u1, Either<(), ()>))))) = 3;
 let (carry, res) = jet_add_32(a, b);
 let add_res = jet_add_32(10, 20);
 let (carry2, res3) = add_res;

--- a/example_progs/assertr.simpl
+++ b/example_progs/assertr.simpl
@@ -1,6 +1,8 @@
-let res = jet_parse_lock(10);
-let res2 = res;
-let res3 = assertl(res);
-jet_verify(jet_eq_32(assertl(res), 10));
-jet_verify(jet_eq_32(assertl(res2), 10));
-jet_verify(jet_eq_32(res3, 10));
+let l_or_r: Either<u32, u32> = jet_parse_lock(10);
+let l: u32 = unwrap_left(l_or_r);
+jet_verify(jet_eq_32(unwrap_left(l_or_r), 10));
+jet_verify(jet_eq_32(l, 10));
+let l_or_r = Right(11);
+let r = unwrap_right(l_or_r);
+jet_verify(jet_eq_32(unwrap_right(l_or_r), 11));
+jet_verify(jet_eq_32(r, 11));

--- a/example_progs/cat.simpl
+++ b/example_progs/cat.simpl
@@ -1,5 +1,10 @@
-let a : u8 = 16; /* 0x10 */
-let b : u8 = 1;  /* 0x01 */
-let c = 4097;    /* 0x1001 */
-let ab : u16 = (a, b);
+let a = 0x10;
+let b = 0x01;
+let ab: u16 = (a, b);
+let c = 0x1001;
 jet_verify(jet_eq_16(ab, c));
+let a = 0b1011;
+let b = 0b1101;
+let ab: u8 = (a, b);
+let c = 0b10111101;
+jet_verify(jet_eq_8(ab, c));

--- a/example_progs/match.simpl
+++ b/example_progs/match.simpl
@@ -3,3 +3,8 @@ let bit: u1 = match Left(11) {
     Right(y) => jet_le_32(y, 10),
 };
 jet_verify(bit);
+let bit: u1 = match Some(11) {
+    Some(x) => jet_le_32(10, x),
+    None => 0,
+};
+jet_verify(bit);

--- a/example_progs/match.simpl
+++ b/example_progs/match.simpl
@@ -8,3 +8,8 @@ let bit: u1 = match Some(11) {
     None => 0,
 };
 jet_verify(bit);
+let bit: bool = match true {
+    true => 1,
+    false => 0,
+};
+jet_verify(bit);

--- a/example_progs/match.simpl
+++ b/example_progs/match.simpl
@@ -1,0 +1,5 @@
+let bit: u1 = match Left(11) {
+    Left(x) => jet_le_32(10, x),
+    Right(y) => jet_le_32(y, 10),
+};
+jet_verify(bit);

--- a/example_progs/test.simpl
+++ b/example_progs/test.simpl
@@ -1,4 +1,4 @@
-let wit_a;
+let wit_a = witness("a");
 let a = 10;
 let res = 20;
 jet_verify(jet_eq_32(jet_max_32(a, wit_a), res));

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -152,7 +152,10 @@ impl SingleExpression {
                 ProgNode::comp(ProgNode::unit(), ProgNode::const_word(value))
             }
             SingleExpressionInner::BitString(_) => unimplemented!(),
-            SingleExpressionInner::ByteString(_) => unimplemented!(),
+            SingleExpressionInner::ByteString(bytes) => {
+                let value = bytes.to_simplicity();
+                ProgNode::comp(ProgNode::unit(), ProgNode::const_word(value))
+            }
             SingleExpressionInner::Witness(identifier) => ProgNode::witness(identifier.clone()),
             SingleExpressionInner::Variable(identifier) => {
                 let res = scope.get(identifier);

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -151,7 +151,10 @@ impl SingleExpression {
                 let value = ty.parse_decimal(decimal);
                 ProgNode::comp(ProgNode::unit(), ProgNode::const_word(value))
             }
-            SingleExpressionInner::BitString(_) => unimplemented!(),
+            SingleExpressionInner::BitString(bits) => {
+                let value = bits.to_simplicity();
+                ProgNode::comp(ProgNode::unit(), ProgNode::const_word(value))
+            }
             SingleExpressionInner::ByteString(bytes) => {
                 let value = bytes.to_simplicity();
                 ProgNode::comp(ProgNode::unit(), ProgNode::const_word(value))

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -34,8 +34,8 @@ fn eval_blk(
             let right = eval_blk(stmts, scope, index + 1, last_expr);
             ProgNode::comp(left, right)
         }
-        Statement::WitnessDecl(witness_ident) => {
-            scope.insert_witness(witness_ident.to_string());
+        Statement::WitnessDecl(name) => {
+            scope.insert_witness(name.clone());
             eval_blk(stmts, scope, index + 1, last_expr)
         }
         Statement::FuncCall(func_call) => {
@@ -149,7 +149,10 @@ impl SingleExpression {
                 let value = bytes.to_simplicity();
                 ProgNode::comp(ProgNode::unit(), ProgNode::const_word(value))
             }
-            SingleExpressionInner::Witness(identifier) => ProgNode::witness(identifier.clone()),
+            SingleExpressionInner::Witness(name) => {
+                scope.insert_witness(name.clone());
+                ProgNode::witness(name.as_inner().clone())
+            }
             SingleExpressionInner::Variable(identifier) => {
                 let res = scope.get(identifier);
                 println!("Identifier {}: {}", identifier, res.arrow());

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -124,6 +124,8 @@ impl SingleExpression {
                 let r = r.eval(scope, None);
                 ProgNode::injr(r)
             }
+            SingleExpressionInner::False => ProgNode::injl(ProgNode::unit()),
+            SingleExpressionInner::True => ProgNode::injr(ProgNode::unit()),
             SingleExpressionInner::Product(l, r) => {
                 let l = l.eval(scope, None);
                 let r = r.eval(scope, None);

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -44,17 +44,6 @@ fn eval_blk(
             let right = eval_blk(stmts, scope, index + 1, last_expr);
             combine_seq(left, right)
         }
-        Statement::DestructTuple(tuple) => {
-            let expr = tuple.expression.eval(scope, tuple.ty.as_ref());
-            scope.insert(Pattern::Product(
-                Arc::new(Pattern::Identifier(tuple.l_ident.clone())),
-                Arc::new(Pattern::Identifier(tuple.r_ident.clone())),
-            ));
-            let left = ProgNode::pair(expr, ProgNode::iden());
-
-            let right = eval_blk(stmts, scope, index + 1, last_expr);
-            ProgNode::comp(left, right)
-        }
     }
 }
 

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -34,10 +34,6 @@ fn eval_blk(
             let right = eval_blk(stmts, scope, index + 1, last_expr);
             ProgNode::comp(left, right)
         }
-        Statement::WitnessDecl(name) => {
-            scope.insert_witness(name.clone());
-            eval_blk(stmts, scope, index + 1, last_expr)
-        }
         Statement::FuncCall(func_call) => {
             let left = func_call.eval(scope, None);
             let right = eval_blk(stmts, scope, index + 1, last_expr);

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -4,14 +4,14 @@ use std::{str::FromStr, sync::Arc};
 
 use simplicity::{jet::Elements, node, FailEntropy, Value};
 
-use crate::parse::UIntType;
+use crate::parse::{Pattern, UIntType};
 use crate::{
     named::{ConstructExt, NamedConstructNode, ProgExt},
     parse::{
         ConstantsInner, Expression, ExpressionInner, FuncCall, FuncType, Program, SingleExpression,
         Statement, Term, TermInner, Type,
     },
-    scope::{GlobalScope, Variable},
+    scope::GlobalScope,
     ProgNode,
 };
 
@@ -30,7 +30,7 @@ fn eval_blk(
     match &stmts[index] {
         Statement::Assignment(assignment) => {
             let expr = assignment.expression.eval(scope, assignment.ty.as_ref());
-            scope.insert(Variable::Single(Arc::clone(&assignment.identifier)));
+            scope.insert(assignment.pattern.clone());
             let left = ProgNode::pair(expr, ProgNode::iden());
             let right = eval_blk(stmts, scope, index + 1, last_expr);
             ProgNode::comp(left, right)
@@ -46,9 +46,9 @@ fn eval_blk(
         }
         Statement::DestructTuple(tuple) => {
             let expr = tuple.expression.eval(scope, tuple.ty.as_ref());
-            scope.insert(Variable::Tuple(
-                tuple.l_ident.clone(),
-                tuple.r_ident.clone(),
+            scope.insert(Pattern::Product(
+                Arc::new(Pattern::Identifier(tuple.l_ident.clone())),
+                Arc::new(Pattern::Identifier(tuple.r_ident.clone())),
             ));
             let left = ProgNode::pair(expr, ProgNode::iden());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,6 +166,7 @@ mod tests {
         _test_progs("./example_progs/nesting.simpl");
         _test_progs("./example_progs/add.simpl");
         _test_progs("./example_progs/cat.simpl");
+        _test_progs("./example_progs/match.simpl");
         // _test_progs("./add_with_builtins.simpl");
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,6 +165,7 @@ mod tests {
         _test_progs("./example_progs/scopes.simpl");
         _test_progs("./example_progs/nesting.simpl");
         _test_progs("./example_progs/add.simpl");
+        _test_progs("./example_progs/cat.simpl");
         // _test_progs("./add_with_builtins.simpl");
     }
 

--- a/src/minimal.pest
+++ b/src/minimal.pest
@@ -22,7 +22,9 @@ assignment        =  { "let" ~ pattern ~ (":" ~ ty)? ~ "=" ~ expression }
 
 left_pattern      =  { "Left(" ~ identifier ~ ")" }
 right_pattern     =  { "Right(" ~ identifier ~ ")" }
-match_pattern     =  { left_pattern | right_pattern }
+none_pattern      =  { "None" }
+some_pattern      =  { "Some(" ~ identifier ~ ")" }
+match_pattern     =  { left_pattern | right_pattern | none_pattern | some_pattern }
 
 unit_type         =  { "()" }
 sum_type          =  { "Either<" ~ ty ~ "," ~ ty ~ ">" }

--- a/src/minimal.pest
+++ b/src/minimal.pest
@@ -20,6 +20,10 @@ product_pattern   =  { "(" ~ pattern ~ "," ~ pattern ~ ")" }
 pattern           =  { variable_pattern | ignore_pattern | product_pattern }
 assignment        =  { "let" ~ pattern ~ (":" ~ ty)? ~ "=" ~ expression }
 
+left_pattern      =  { "Left(" ~ identifier ~ ")" }
+right_pattern     =  { "Right(" ~ identifier ~ ")" }
+match_pattern     =  { left_pattern | right_pattern }
+
 unit_type         =  { "()" }
 sum_type          =  { "Either<" ~ ty ~ "," ~ ty ~ ">" }
 product_type      =  { "(" ~ ty ~ "," ~ ty ~ ")" }
@@ -45,4 +49,6 @@ bit_string        =  { "0b" ~ ASCII_BIN_DIGIT+ }
 byte_string       =  { "0x" ~ ASCII_HEX_DIGIT+ }
 witness_expr      =  { "witness(\"" ~ witness_name ~ "\")" }
 variable_expr     =  { identifier }
-single_expression =  { unit_expr | left_expr | right_expr | product_expr | none_expr | some_expr | func_call | bit_string | byte_string | unsigned_integer | witness_expr | variable_expr | "(" ~ expression ~ ")" }
+match_arm         =  { match_pattern ~ "=>" ~ (single_expression ~ "," | block_expression ~ ","?) }
+match_expr        =  { "match" ~ expression ~ "{" ~ match_arm ~ match_arm ~ "}" }
+single_expression =  { unit_expr | left_expr | right_expr | product_expr | none_expr | some_expr | func_call | match_expr | bit_string | byte_string | unsigned_integer | witness_expr | variable_expr | "(" ~ expression ~ ")" }

--- a/src/minimal.pest
+++ b/src/minimal.pest
@@ -10,6 +10,11 @@ statement = { assignment | witness_decl | func_call }
 witness_decl = _{ "let" ~ witness}
 
 identifier        = @{ !(reserved) ~ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_")* }
+jet               = @{ "jet_" ~ (ASCII_ALPHANUMERIC | "_")+ }
+builtin           = @{ "builtin_" ~ (ASCII_ALPHANUMERIC | "_")+ }
+witness           = @{ "wit_" ~ (ASCII_ALPHANUMERIC | "_")+ }
+reserved          = _{ jet | builtin | witness }
+
 variable_pattern  =  { identifier }
 ignore_pattern    =  { "_" }
 product_pattern   =  { "(" ~ pattern ~ "," ~ pattern ~ ")" }
@@ -23,14 +28,6 @@ option_type       =  { "Option<" ~ ty ~ ">" }
 unsigned_type     =  { "u128" | "u256" | "u16" | "u32" | "u64" | "u1" | "u2" | "u4" | "u8" }
 ty                =  { unit_type | sum_type | product_type | option_type | unsigned_type }
 
-jet = @{"jet_" ~ (ASCII_ALPHANUMERIC | "_")+}
-builtin = @{"builtin_" ~ (ASCII_ALPHANUMERIC | "_")+}
-asserts = _{ assertl | assertr}
-assertl = @{"assertl"}
-assertr = @{"assertr"}
-witness = @{"wit_" ~ (ASCII_ALPHANUMERIC | "_")+}
-reserved = _{ jet | witness | builtin | asserts }
-
 expression        =  { block_expression | single_expression }
 block_expression  =  { "{" ~ (statement ~ ";")* ~ expression ~ "}" }
 unit_expr         =  { "()" }
@@ -39,12 +36,14 @@ right_expr        =  { "Right(" ~ expression ~ ")" }
 product_expr      =  { "(" ~ expression ~ "," ~ expression ~ ")" }
 none_expr         =  { "None" }
 some_expr         =  { "Some(" ~ expression ~ ")" }
+jet_expr          =  { jet ~ "(" ~ (expression ~ ("," ~ expression)*)? ~ ")" }
+unwrap_left_expr  =  { "unwrap_left(" ~ expression ~ ")" }
+unwrap_right_expr =  { "unwrap_right(" ~ expression ~ ")" }
+unwrap_expr       =  { "unwrap(" ~ expression ~ ")" }
+func_call         =  { jet_expr | unwrap_left_expr | unwrap_right_expr | unwrap_expr }
 unsigned_integer  =  { ASCII_DIGIT+ }
 bit_string        =  { "0b" ~ ASCII_BIN_DIGIT+ }
 byte_string       =  { "0x" ~ ASCII_HEX_DIGIT+ }
 witness_expr      =  { witness }
 variable_expr     =  { identifier }
 single_expression =  { unit_expr | left_expr | right_expr | product_expr | none_expr | some_expr | func_call | bit_string | byte_string | unsigned_integer | witness_expr | variable_expr | "(" ~ expression ~ ")" }
-
-// In built functions
-func_call = { (jet | builtin) ~ "(" ~ (expression ~ ("," ~ expression)*)? ~ ")" | asserts ~ "(" ~ expression ~ ")" }

--- a/src/minimal.pest
+++ b/src/minimal.pest
@@ -6,14 +6,13 @@ program = {
     (statement ~ ";")* ~
     EOI
 }
-statement = { assignment | witness_decl | func_call }
-witness_decl = _{ "let" ~ witness}
+statement = { assignment | func_call }
 
 identifier        = @{ !(reserved) ~ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_")* }
 jet               = @{ "jet_" ~ (ASCII_ALPHANUMERIC | "_")+ }
 builtin           = @{ "builtin_" ~ (ASCII_ALPHANUMERIC | "_")+ }
-witness           = @{ "wit_" ~ (ASCII_ALPHANUMERIC | "_")+ }
-reserved          = _{ jet | builtin | witness }
+witness_name      = @{ (ASCII_ALPHANUMERIC | "_")+ }
+reserved          = _{ jet | builtin }
 
 variable_pattern  =  { identifier }
 ignore_pattern    =  { "_" }
@@ -44,6 +43,6 @@ func_call         =  { jet_expr | unwrap_left_expr | unwrap_right_expr | unwrap_
 unsigned_integer  =  { ASCII_DIGIT+ }
 bit_string        =  { "0b" ~ ASCII_BIN_DIGIT+ }
 byte_string       =  { "0x" ~ ASCII_HEX_DIGIT+ }
-witness_expr      =  { witness }
+witness_expr      =  { "witness(\"" ~ witness_name ~ "\")" }
 variable_expr     =  { identifier }
 single_expression =  { unit_expr | left_expr | right_expr | product_expr | none_expr | some_expr | func_call | bit_string | byte_string | unsigned_integer | witness_expr | variable_expr | "(" ~ expression ~ ")" }

--- a/src/minimal.pest
+++ b/src/minimal.pest
@@ -16,19 +16,12 @@ product_pattern   =  { "(" ~ pattern ~ "," ~ pattern ~ ")" }
 pattern           =  { variable_pattern | ignore_pattern | product_pattern }
 assignment        =  { "let" ~ pattern ~ (":" ~ ty)? ~ "=" ~ expression }
 
-expression = { block_expression | pair | single_expression }
-single_expression = {term}
-block_expression = { "{" ~ (statement ~ ";")* ~ expression ~ "}" }
-pair = {"(" ~ expression ~ "," ~ expression  ~ ")"}
-
 unit_type         =  { "()" }
 sum_type          =  { "Either<" ~ ty ~ "," ~ ty ~ ">" }
 product_type      =  { "(" ~ ty ~ "," ~ ty ~ ")" }
 option_type       =  { "Option<" ~ ty ~ ">" }
 unsigned_type     =  { "u128" | "u256" | "u16" | "u32" | "u64" | "u1" | "u2" | "u4" | "u8" }
 ty                =  { unit_type | sum_type | product_type | option_type | unsigned_type }
-
-term = { func_call | constants | witness | identifier | "(" ~ expression ~ ")" }
 
 jet = @{"jet_" ~ (ASCII_ALPHANUMERIC | "_")+}
 builtin = @{"builtin_" ~ (ASCII_ALPHANUMERIC | "_")+}
@@ -38,13 +31,20 @@ assertr = @{"assertr"}
 witness = @{"wit_" ~ (ASCII_ALPHANUMERIC | "_")+}
 reserved = _{ jet | witness | builtin | asserts }
 
-constants = { unit | none | false_ | true_ | number }
-unit = { "()" }
-none = { "None" }
-number = @{ hex_number| (ASCII_DIGIT)+}
-false_ = { "False" }
-true_ = { "True" }
-hex_number = @{ "0x" ~ (HEX_DIGIT)+ }
+expression        =  { block_expression | single_expression }
+block_expression  =  { "{" ~ (statement ~ ";")* ~ expression ~ "}" }
+unit_expr         =  { "()" }
+left_expr         =  { "Left(" ~ expression ~ ")" }
+right_expr        =  { "Right(" ~ expression ~ ")" }
+product_expr      =  { "(" ~ expression ~ "," ~ expression ~ ")" }
+none_expr         =  { "None" }
+some_expr         =  { "Some(" ~ expression ~ ")" }
+unsigned_integer  =  { ASCII_DIGIT+ }
+bit_string        =  { "0b" ~ ASCII_BIN_DIGIT+ }
+byte_string       =  { "0x" ~ ASCII_HEX_DIGIT+ }
+witness_expr      =  { witness }
+variable_expr     =  { identifier }
+single_expression =  { unit_expr | left_expr | right_expr | product_expr | none_expr | some_expr | func_call | bit_string | byte_string | unsigned_integer | witness_expr | variable_expr | "(" ~ expression ~ ")" }
 
 // In built functions
 func_call = { (jet | builtin) ~ "(" ~ (expression ~ ("," ~ expression)*)? ~ ")" | asserts ~ "(" ~ expression ~ ")" }

--- a/src/minimal.pest
+++ b/src/minimal.pest
@@ -8,7 +8,14 @@ program = {
 }
 statement = { assignment | destruct_pair| witness_decl |  func_call }
 witness_decl = _{ "let" ~ witness}
-assignment = { "let" ~ identifier ~ (":" ~ ty)? ~ "=" ~ expression }
+
+identifier        = @{ !(reserved) ~ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_")* }
+variable_pattern  =  { identifier }
+ignore_pattern    =  { "_" }
+product_pattern   =  { "(" ~ pattern ~ "," ~ pattern ~ ")" }
+pattern           =  { variable_pattern | ignore_pattern | product_pattern }
+assignment        =  { "let" ~ pattern ~ (":" ~ ty)? ~ "=" ~ expression }
+
 destruct_pair = { "let" ~ "(" ~ identifier ~ ("," ~ identifier) ~ ")" ~ (":" ~ ty)? ~ "=" ~ expression }
 
 expression = { block_expression | pair | single_expression }
@@ -23,7 +30,7 @@ option_type       =  { "Option<" ~ ty ~ ">" }
 unsigned_type     =  { "u128" | "u256" | "u16" | "u32" | "u64" | "u1" | "u2" | "u4" | "u8" }
 ty                =  { unit_type | sum_type | product_type | option_type | unsigned_type }
 
-term = { func_call | constants | witness | identifier| "(" ~ expression ~ ")"}
+term = { func_call | constants | witness | identifier | "(" ~ expression ~ ")" }
 
 jet = @{"jet_" ~ (ASCII_ALPHANUMERIC | "_")+}
 builtin = @{"builtin_" ~ (ASCII_ALPHANUMERIC | "_")+}
@@ -32,8 +39,6 @@ assertl = @{"assertl"}
 assertr = @{"assertr"}
 witness = @{"wit_" ~ (ASCII_ALPHANUMERIC | "_")+}
 reserved = _{ jet | witness | builtin | asserts }
-
-identifier = @{ !(reserved) ~ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
 
 constants = { unit | none | false_ | true_ | number }
 unit = { "()" }

--- a/src/minimal.pest
+++ b/src/minimal.pest
@@ -1,4 +1,4 @@
-WHITESPACE = _{ " " | "\n" | "\t" }
+WHITESPACE = _{ " " | "\t" | "\n" | "\r" }
 
 COMMENT = _{ "/*" ~ (!"*/" ~ ANY)* ~ "*/" }
 

--- a/src/minimal.pest
+++ b/src/minimal.pest
@@ -24,14 +24,17 @@ left_pattern      =  { "Left(" ~ identifier ~ ")" }
 right_pattern     =  { "Right(" ~ identifier ~ ")" }
 none_pattern      =  { "None" }
 some_pattern      =  { "Some(" ~ identifier ~ ")" }
-match_pattern     =  { left_pattern | right_pattern | none_pattern | some_pattern }
+false_pattern     =  { "false" }
+true_pattern      =  { "true" }
+match_pattern     =  { left_pattern | right_pattern | none_pattern | some_pattern | false_pattern | true_pattern }
 
 unit_type         =  { "()" }
 sum_type          =  { "Either<" ~ ty ~ "," ~ ty ~ ">" }
 product_type      =  { "(" ~ ty ~ "," ~ ty ~ ")" }
 option_type       =  { "Option<" ~ ty ~ ">" }
+boolean_type      =  { "bool" }
 unsigned_type     =  { "u128" | "u256" | "u16" | "u32" | "u64" | "u1" | "u2" | "u4" | "u8" }
-ty                =  { unit_type | sum_type | product_type | option_type | unsigned_type }
+ty                =  { unit_type | sum_type | product_type | option_type | boolean_type | unsigned_type }
 
 expression        =  { block_expression | single_expression }
 block_expression  =  { "{" ~ (statement ~ ";")* ~ expression ~ "}" }
@@ -41,6 +44,8 @@ right_expr        =  { "Right(" ~ expression ~ ")" }
 product_expr      =  { "(" ~ expression ~ "," ~ expression ~ ")" }
 none_expr         =  { "None" }
 some_expr         =  { "Some(" ~ expression ~ ")" }
+false_expr        =  { "false" }
+true_expr         =  { "true" }
 jet_expr          =  { jet ~ "(" ~ (expression ~ ("," ~ expression)*)? ~ ")" }
 unwrap_left_expr  =  { "unwrap_left(" ~ expression ~ ")" }
 unwrap_right_expr =  { "unwrap_right(" ~ expression ~ ")" }
@@ -53,4 +58,4 @@ witness_expr      =  { "witness(\"" ~ witness_name ~ "\")" }
 variable_expr     =  { identifier }
 match_arm         =  { match_pattern ~ "=>" ~ (single_expression ~ "," | block_expression ~ ","?) }
 match_expr        =  { "match" ~ expression ~ "{" ~ match_arm ~ match_arm ~ "}" }
-single_expression =  { unit_expr | left_expr | right_expr | product_expr | none_expr | some_expr | func_call | match_expr | bit_string | byte_string | unsigned_integer | witness_expr | variable_expr | "(" ~ expression ~ ")" }
+single_expression =  { unit_expr | left_expr | right_expr | product_expr | none_expr | some_expr | false_expr | true_expr | func_call | match_expr | bit_string | byte_string | unsigned_integer | witness_expr | variable_expr | "(" ~ expression ~ ")" }

--- a/src/minimal.pest
+++ b/src/minimal.pest
@@ -16,9 +16,12 @@ single_expression = {term}
 block_expression = { "{" ~ (statement ~ ";")* ~ expression ~ "}" }
 pair = {"(" ~ expression ~ "," ~ expression  ~ ")"}
 
-ty = { unsigned_types | x_only_key_hex }
-unsigned_types = { "u1"| "u2"| "u4"|"u8" | "u16" | "u32" | "u64" | "u256" }
-x_only_key_hex = { "pubkey"}
+unit_type         =  { "()" }
+sum_type          =  { "Either<" ~ ty ~ "," ~ ty ~ ">" }
+product_type      =  { "(" ~ ty ~ "," ~ ty ~ ")" }
+option_type       =  { "Option<" ~ ty ~ ">" }
+unsigned_type     =  { "u128" | "u256" | "u16" | "u32" | "u64" | "u1" | "u2" | "u4" | "u8" }
+ty                =  { unit_type | sum_type | product_type | option_type | unsigned_type }
 
 term = { func_call | constants | witness | identifier| "(" ~ expression ~ ")"}
 

--- a/src/minimal.pest
+++ b/src/minimal.pest
@@ -6,7 +6,7 @@ program = {
     (statement ~ ";")* ~
     EOI
 }
-statement = { assignment | destruct_pair| witness_decl |  func_call }
+statement = { assignment | witness_decl | func_call }
 witness_decl = _{ "let" ~ witness}
 
 identifier        = @{ !(reserved) ~ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_")* }
@@ -15,8 +15,6 @@ ignore_pattern    =  { "_" }
 product_pattern   =  { "(" ~ pattern ~ "," ~ pattern ~ ")" }
 pattern           =  { variable_pattern | ignore_pattern | product_pattern }
 assignment        =  { "let" ~ pattern ~ (":" ~ ty)? ~ "=" ~ expression }
-
-destruct_pair = { "let" ~ "(" ~ identifier ~ ("," ~ identifier) ~ ")" ~ (":" ~ ty)? ~ "=" ~ expression }
 
 expression = { block_expression | pair | single_expression }
 single_expression = {term}

--- a/src/minimal.pest
+++ b/src/minimal.pest
@@ -1,6 +1,5 @@
 WHITESPACE = _{ " " | "\t" | "\n" | "\r" }
-
-COMMENT = _{ "/*" ~ (!"*/" ~ ANY)* ~ "*/" }
+COMMENT = _{ ("/*" ~ (!"*/" ~ ANY)* ~ "*/") | ("//" ~ (!"\n" ~ ANY)*) }
 
 program = {
     SOI ~

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -269,6 +269,7 @@ pub trait PestParse {
 
 impl PestParse for Program {
     fn parse(pair: pest::iterators::Pair<Rule>) -> Self {
+        assert!(matches!(pair.as_rule(), Rule::program));
         let mut stmts = Vec::new();
         for inner_pair in pair.into_inner() {
             match inner_pair.as_rule() {
@@ -283,6 +284,7 @@ impl PestParse for Program {
 
 impl PestParse for Statement {
     fn parse(pair: pest::iterators::Pair<Rule>) -> Self {
+        assert!(matches!(pair.as_rule(), Rule::statement));
         let inner_pair = pair.into_inner().next().unwrap();
         match inner_pair.as_rule() {
             Rule::destruct_pair => Statement::DestructTuple(DestructPair::parse(inner_pair)),
@@ -322,6 +324,7 @@ impl PestParse for DestructPair {
 
 impl PestParse for Assignment {
     fn parse(pair: pest::iterators::Pair<Rule>) -> Self {
+        assert!(matches!(pair.as_rule(), Rule::assignment));
         let source_text = Arc::from(pair.as_str());
         let position = pair.line_col();
         let mut inner_pair = pair.into_inner();

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -24,8 +24,6 @@ pub struct Program {
 pub enum Statement {
     /// A declaration of variables inside a pattern.
     Assignment(Assignment),
-    /// A declaration of a witness.
-    WitnessDecl(WitnessName),
     /// A function call.
     FuncCall(FuncCall),
 }
@@ -453,7 +451,6 @@ impl PestParse for Statement {
         let inner_pair = pair.into_inner().next().unwrap();
         match inner_pair.as_rule() {
             Rule::assignment => Statement::Assignment(Assignment::parse(inner_pair)),
-            Rule::witness => Statement::WitnessDecl(WitnessName::parse(inner_pair)),
             Rule::func_call => Statement::FuncCall(FuncCall::parse(inner_pair)),
             x => panic!("{:?}", x),
         }
@@ -716,7 +713,7 @@ impl PestParse for Bytes {
 
 impl PestParse for WitnessName {
     fn parse(pair: pest::iterators::Pair<Rule>) -> Self {
-        assert!(matches!(pair.as_rule(), Rule::witness));
+        assert!(matches!(pair.as_rule(), Rule::witness_name));
         let name = Arc::from(pair.as_str());
         WitnessName(name)
     }

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -1,6 +1,6 @@
 use miniscript::iter::TreeLike;
 
-use crate::parse::{Identifier, Pattern};
+use crate::parse::{Identifier, Pattern, WitnessName};
 use crate::{named::ProgExt, ProgNode};
 
 /// A global scope is a stack of scopes.
@@ -13,7 +13,7 @@ use crate::{named::ProgExt, ProgNode};
 #[derive(Debug)]
 pub struct GlobalScope {
     variables: Vec<Vec<Pattern>>,
-    witnesses: Vec<Vec<String>>,
+    witnesses: Vec<Vec<WitnessName>>,
 }
 
 impl Default for GlobalScope {
@@ -53,7 +53,7 @@ impl GlobalScope {
     }
 
     /// Pushes a new witness to the latest scope.
-    pub fn insert_witness(&mut self, key: String) {
+    pub fn insert_witness(&mut self, key: WitnessName) {
         self.witnesses.last_mut().unwrap().push(key);
     }
 

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -1,6 +1,6 @@
 use miniscript::iter::TreeLike;
 
-use crate::parse::Pattern;
+use crate::parse::{Identifier, Pattern};
 use crate::{named::ProgExt, ProgNode};
 
 /// A global scope is a stack of scopes.
@@ -66,7 +66,7 @@ impl GlobalScope {
     /// # Panics
     ///
     /// Panics if the variable is not found.
-    pub fn get(&self, key: &str) -> ProgNode {
+    pub fn get(&self, key: &Identifier) -> ProgNode {
         // search in the vector of vectors from the end
         let mut pos = 0;
         let mut var = None;
@@ -94,14 +94,14 @@ impl GlobalScope {
 }
 
 impl Pattern {
-    pub fn get_identifier(&self) -> Option<&str> {
+    pub fn get_identifier(&self) -> Option<&Identifier> {
         match self {
-            Pattern::Identifier(s) => Some(s),
+            Pattern::Identifier(i) => Some(i),
             _ => None,
         }
     }
 
-    pub fn contains(&self, identifier: &str) -> bool {
+    pub fn contains(&self, identifier: &Identifier) -> bool {
         self.pre_order_iter().any(|pattern| {
             pattern
                 .get_identifier()
@@ -110,7 +110,7 @@ impl Pattern {
         })
     }
 
-    pub fn get_program(&self, identifier: &str) -> Option<ProgNode> {
+    pub fn get_program(&self, identifier: &Identifier) -> Option<ProgNode> {
         enum Direction {
             Left,
             Right,
@@ -122,7 +122,7 @@ impl Pattern {
         loop {
             match pattern {
                 Pattern::Identifier(i) => {
-                    if i.as_ref() == identifier {
+                    if i == identifier {
                         break;
                     } else {
                         return None;

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -10,7 +10,7 @@ use crate::{named::ProgExt, ProgNode};
 /// Our simplicity translation looks at the index
 /// of the variable from the end of stack to figure it's
 /// position in the environment.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct GlobalScope {
     variables: Vec<Vec<Pattern>>,
     witnesses: Vec<Vec<WitnessName>>,


### PR DESCRIPTION
Implementation of new syntax and semantics from #6: types, values, match statements, unwraps.

The Simplicity compiler panics on every error, as on master. I will fix this in a follow-up PR.

Types and patterns are parsed nonrecursively. Expressions are more complicated and are currently parsed recursively. There will be a follow-up PR.