### PR TITLE
Array patterns

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,8 @@
 name = "s-lang"
 version = "0.1.0"
 authors = ["sanket1729 <sanket1729@gmail.com>"]
-edition = "2018"
+edition = "2021"
+rust-version = "1.61.0"
 
 [lib]
 name = "s_lang"

--- a/example_progs/array.simpl
+++ b/example_progs/array.simpl
@@ -56,3 +56,7 @@ let j1: [bool; 3] = [false, false, true];
 let j2: ((bool, bool), bool) = j1;
 let k1: [bool; 5] = [false, false, false, false, true];
 let k2: (((bool, bool), (bool, bool)), bool) = k1;
+let [l, m, n] = [1, 2, 3];
+jet_verify(jet_eq_32(1, l));
+jet_verify(jet_eq_32(2, m));
+jet_verify(jet_eq_32(3, n));

--- a/src/array.rs
+++ b/src/array.rs
@@ -1,12 +1,15 @@
 use miniscript::iter::{Tree, TreeLike};
 
-/// View of a slice as a balanced binary tree of its elements.
+/// View of a slice as a balanced binary tree.
 /// The slice must be nonempty.
+///
+/// Each node is labelled with a slice.
+/// Leaves contain single elements.
 #[derive(Debug, Copy, Clone)]
 pub struct BTreeSlice<'a, A>(&'a [A]);
 
 impl<'a, A> BTreeSlice<'a, A> {
-    /// View the slice as a balanced binary tree of its elements.
+    /// View the slice as a balanced binary tree.
     ///
     /// ## Panics
     ///

--- a/src/array.rs
+++ b/src/array.rs
@@ -5,7 +5,7 @@ use miniscript::iter::{Tree, TreeLike};
 ///
 /// Each node is labelled with a slice.
 /// Leaves contain single elements.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct BTreeSlice<'a, A>(&'a [A]);
 
 impl<'a, A> BTreeSlice<'a, A> {
@@ -81,7 +81,7 @@ impl<'a, A: Clone> TreeLike for BTreeSlice<'a, A> {
 /// 3. A slice of length `1 < l < N` is a parent:
 ///     1. Left child: The empty block
 ///     2. Right child: The partition of the remaining `l` elements
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum Partition<'a, A> {
     Leaf(&'a [A]),
     Parent { slice: &'a [A], block_len: usize },

--- a/src/array.rs
+++ b/src/array.rs
@@ -1,3 +1,7 @@
+use std::fmt;
+use std::ops::Range;
+use std::sync::Arc;
+
 use miniscript::iter::{Tree, TreeLike};
 
 /// View of a slice as a balanced binary tree.
@@ -179,6 +183,150 @@ impl<'a, A: Clone> TreeLike for Partition<'a, A> {
                 };
                 Tree::Binary(l, r)
             }
+        }
+    }
+}
+
+/// Convert a tree into a binary tree.
+/// Each node has fanout at most two.
+///
+/// Nodes with at most two children (non-arrays) are preserved in the binary tree.
+/// We call these nodes _normal nodes_.
+///
+/// Nodes with more than two children (arrays) are converted into balanced binary trees.
+///
+/// ## Example
+///
+/// Take a root node with children `a`, `b`, `c`.
+///
+/// ```text
+///    .
+///  / | \
+/// a  b  c
+/// ```
+///
+/// The 3-ary root is converted into two 2-ary nodes. The normal nodes `a`, `b`, `c` stay preserved.
+///
+/// ```text
+///     .
+///    / \
+///   .   c
+///  / \
+/// a   b
+/// ```
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct BinaryTree<T>(BinaryTreeInner<T>);
+
+impl<T> BinaryTree<T> {
+    /// Access the content of a normal node.
+    pub fn as_normal(&self) -> Option<&T> {
+        match &self.0 {
+            BinaryTreeInner::Normal(tree) => Some(tree),
+            _ => None,
+        }
+    }
+}
+
+impl<T: TreeLike> BinaryTree<T> {
+    /// Convert a tree into a binary tree.
+    ///
+    /// ## Panics
+    ///
+    /// `<T as TreeLike>::as_node` returns `Tree::Nary` with an empty array.
+    pub fn from_tree(tree: T) -> Self {
+        Self(BinaryTreeInner::normal(tree))
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+enum BinaryTreeInner<T> {
+    /// Normal node (with at most two children).
+    ///
+    /// Must be constructed via [`BinaryTreeInner::normal()`].
+    Normal(T),
+    /// Array of at least two children.
+    ///
+    /// Must be constructed via [`BinaryTreeInner::array()`].
+    Array(Arc<[T]>, Range<usize>),
+}
+
+impl<T: TreeLike> BinaryTreeInner<T> {
+    /// Construct a binary tree from a tree.
+    ///
+    /// ## Panics
+    ///
+    /// `<T as TreeLike>::as_node` returns `Tree::Nary` with an empty array.
+    // FIXME: Remove recursion
+    fn normal(tree: T) -> Self {
+        match tree.as_node() {
+            Tree::Nary(array) => {
+                let range = 0..array.len();
+                Self::array(array, range)
+            }
+            _ => Self::Normal(tree),
+        }
+    }
+
+    /// Construct a binary tree from an array.
+    ///
+    /// ## Panics
+    ///
+    /// Array is empty. Range is empty.
+    ///
+    /// `<T as TreeLike>::as_node` returns `Tree::Nary` with an empty array.
+    // FIXME: Remove recursion
+    fn array(array: Arc<[T]>, range: Range<usize>) -> Self {
+        assert!(!array.is_empty(), "Arrays must be nonempty");
+        match range.len() {
+            0 => panic!("Range must be nonempty"),
+            1 => Self::normal(array[range.start].clone()),
+            _ => Self::Array(array, range),
+        }
+    }
+}
+
+impl<T: TreeLike> TreeLike for BinaryTree<T> {
+    /// # Panics
+    ///
+    /// `<T as TreeLike>::as_node` returns `Tree::Nary` with an empty array.
+    fn as_node(&self) -> Tree<Self> {
+        match &self.0 {
+            BinaryTreeInner::Normal(tree) => match tree.as_node() {
+                Tree::Nullary => Tree::Nullary,
+                Tree::Unary(l) => Tree::Unary(Self(BinaryTreeInner::normal(l))),
+                Tree::Binary(l, r) => Tree::Binary(
+                    Self(BinaryTreeInner::normal(l)),
+                    Self(BinaryTreeInner::normal(r)),
+                ),
+                Tree::Nary(array) => {
+                    let range = 0..array.len();
+                    Self(BinaryTreeInner::array(array, range)).as_node()
+                }
+            },
+            BinaryTreeInner::Array(array, range) => {
+                debug_assert!(2 <= range.len());
+                let n = range.len();
+                let next_pow2 = n.next_power_of_two();
+                let half = next_pow2 / 2;
+                let left = Self(BinaryTreeInner::array(
+                    Arc::clone(array),
+                    range.start..range.start + half,
+                ));
+                let right = Self(BinaryTreeInner::array(
+                    Arc::clone(array),
+                    range.start + half..range.end,
+                ));
+                Tree::Binary(left, right)
+            }
+        }
+    }
+}
+
+impl<T: TreeLike + fmt::Display> fmt::Display for BinaryTree<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.0 {
+            BinaryTreeInner::Normal(tree) => write!(f, "{tree}"),
+            BinaryTreeInner::Array(..) => write!(f, "."),
         }
     }
 }

--- a/src/minimal.pest
+++ b/src/minimal.pest
@@ -17,7 +17,8 @@ reserved          = _{ jet | builtin }
 variable_pattern  =  { identifier }
 ignore_pattern    =  { "_" }
 product_pattern   =  { "(" ~ pattern ~ "," ~ pattern ~ ")" }
-pattern           =  { variable_pattern | ignore_pattern | product_pattern }
+array_pattern     =  { "[" ~ pattern ~ ("," ~ pattern)* ~ ","? ~ "]" }
+pattern           =  { ignore_pattern | product_pattern | array_pattern | variable_pattern }
 assignment        =  { "let" ~ pattern ~ (":" ~ ty)? ~ "=" ~ expression }
 
 left_pattern      =  { "Left(" ~ identifier ~ ")" }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -38,6 +38,8 @@ pub enum Pattern {
     Ignore,
     /// Split product value. Bind components to first and second pattern, respectively.
     Product(Arc<Self>, Arc<Self>),
+    /// Split array value. Bind components to balanced binary tree of patterns.
+    Array(Vec<Self>),
 }
 
 impl Pattern {
@@ -78,6 +80,7 @@ impl<'a> TreeLike for &'a Pattern {
         match self {
             Pattern::Identifier(_) | Pattern::Ignore => Tree::Nullary,
             Pattern::Product(l, r) => Tree::Binary(l, r),
+            Pattern::Array(children) => Tree::Nary(children.iter().collect()),
         }
     }
 }
@@ -95,6 +98,11 @@ impl fmt::Display for Pattern {
                         debug_assert!(n == 2);
                         write!(f, ")")?;
                     }
+                },
+                Pattern::Array(children) => match data.n_children_yielded {
+                    0 => write!(f, "[")?,
+                    n if n == children.len() => write!(f, "]")?,
+                    _ => write!(f, ",")?,
                 },
             }
         }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -681,6 +681,11 @@ impl PestParse for Pattern {
                     let l = output.pop().unwrap();
                     output.push(Pattern::Product(Arc::new(l), Arc::new(r)));
                 }
+                Rule::array_pattern => {
+                    assert!(0 < data.node.n_children(), "Array must be nonempty");
+                    let children = output.split_off(output.len() - data.node.n_children());
+                    output.push(Pattern::Array(children));
+                }
                 _ => unreachable!("Corrupt grammar"),
             }
         }
@@ -1120,6 +1125,10 @@ impl<'a> TreeLike for PatternPair<'a> {
                 let l = it.next().unwrap();
                 let r = it.next().unwrap();
                 Tree::Binary(PatternPair(l), PatternPair(r))
+            }
+            Rule::array_pattern => {
+                let children: Arc<[PatternPair]> = it.map(PatternPair).collect();
+                Tree::Nary(children)
             }
             _ => unreachable!("Corrupt grammar"),
         }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -43,6 +43,16 @@ pub enum Pattern {
 }
 
 impl Pattern {
+    /// Construct a product pattern.
+    pub fn product(l: Self, r: Self) -> Self {
+        Self::Product(Arc::new(l), Arc::new(r))
+    }
+
+    /// Construct an array pattern.
+    pub fn array<I: IntoIterator<Item = Self>>(array: I) -> Self {
+        Self::Array(array.into_iter().collect())
+    }
+
     /// Create an equivalent pattern that corresponds to the Simplicity base types.
     ///
     /// ## Base patterns
@@ -114,6 +124,12 @@ impl fmt::Display for Pattern {
 /// Identifier of a variable.
 #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct Identifier(Arc<str>);
+
+impl Identifier {
+    pub fn from_str_unchecked(str: &str) -> Self {
+        Self(Arc::from(str))
+    }
+}
 
 impl fmt::Display for Identifier {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -14,14 +14,14 @@ use crate::array::{BTreeSlice, Partition};
 use crate::Rule;
 
 /// A complete simplicity program.
-#[derive(Debug)]
+#[derive(Clone, Debug, Hash)]
 pub struct Program {
     /// The statements in the program.
     pub statements: Vec<Statement>,
 }
 
 /// A statement in a simplicity program.
-#[derive(Debug)]
+#[derive(Clone, Debug, Hash)]
 pub enum Statement {
     /// A declaration of variables inside a pattern.
     Assignment(Assignment),
@@ -30,7 +30,7 @@ pub enum Statement {
 }
 
 /// Pattern for binding values to variables.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum Pattern {
     /// Bind value to variable name.
     Identifier(Identifier),
@@ -50,7 +50,7 @@ impl<'a> TreeLike for &'a Pattern {
 }
 
 /// Identifier of a variable.
-#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct Identifier(Arc<str>);
 
 impl fmt::Display for Identifier {
@@ -60,7 +60,7 @@ impl fmt::Display for Identifier {
 }
 
 /// The output of an expression is assigned to a pattern.
-#[derive(Debug)]
+#[derive(Clone, Debug, Hash)]
 pub struct Assignment {
     /// The pattern.
     pub pattern: Pattern,
@@ -81,7 +81,7 @@ pub struct Assignment {
 /// Since jets in simplicity operate on a single paired type,
 /// the arguments are paired together.
 /// jet(a, b, c, d) = jet(pair(pair(pair(a, b), c), d))
-#[derive(Debug)]
+#[derive(Clone, Debug, Hash)]
 pub struct FuncCall {
     /// The type of the function.
     pub func_type: FuncType,
@@ -94,7 +94,7 @@ pub struct FuncCall {
 }
 
 /// A function(jet) name.
-#[derive(Debug)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub enum FuncType {
     /// A jet name.
     Jet(Arc<str>),
@@ -109,7 +109,7 @@ pub enum FuncType {
 }
 
 /// An expression is something that returns a value.
-#[derive(Debug)]
+#[derive(Clone, Debug, Hash)]
 pub struct Expression {
     /// The kind of expression
     pub inner: ExpressionInner,
@@ -120,7 +120,7 @@ pub struct Expression {
 }
 
 /// The kind of expression.
-#[derive(Debug)]
+#[derive(Clone, Debug, Hash)]
 pub enum ExpressionInner {
     /// A block expression executes a series of statements
     /// and returns the value of the final expression.
@@ -130,7 +130,7 @@ pub enum ExpressionInner {
 }
 
 /// A single expression directly returns a value.
-#[derive(Debug)]
+#[derive(Clone, Debug, Hash)]
 pub struct SingleExpression {
     /// The kind of single expression
     pub inner: SingleExpressionInner,
@@ -141,7 +141,7 @@ pub struct SingleExpression {
 }
 
 /// The kind of single expression.
-#[derive(Debug)]
+#[derive(Clone, Debug, Hash)]
 pub enum SingleExpressionInner {
     /// Unit literal expression
     Unit,
@@ -191,7 +191,7 @@ pub enum SingleExpressionInner {
 }
 
 /// Bit string whose length is a power of two.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub enum Bits {
     /// Least significant bit of byte
     U1(u8),
@@ -216,7 +216,7 @@ impl Bits {
 }
 
 /// Byte string whose length is a power of two.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct Bytes(pub Vec<u8>);
 
 impl Bytes {
@@ -227,7 +227,7 @@ impl Bytes {
 }
 
 /// String that is a witness name.
-#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct WitnessName(Arc<str>);
 
 impl WitnessName {
@@ -244,7 +244,7 @@ impl fmt::Display for WitnessName {
 }
 
 /// Arm of a match expression.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Hash)]
 pub struct MatchArm {
     /// Matched pattern
     pub pattern: MatchPattern,
@@ -253,7 +253,7 @@ pub struct MatchArm {
 }
 
 /// Pattern of a match arm.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Hash)]
 pub enum MatchPattern {
     /// Bind inner value of left value to variable name.
     Left(Identifier),

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -49,6 +49,27 @@ impl<'a> TreeLike for &'a Pattern {
     }
 }
 
+impl fmt::Display for Pattern {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for data in self.verbose_pre_order_iter() {
+            match data.node {
+                Pattern::Identifier(i) => write!(f, "{i}")?,
+                Pattern::Ignore => write!(f, "_")?,
+                Pattern::Product(..) => match data.n_children_yielded {
+                    0 => write!(f, "(")?,
+                    1 => write!(f, ",")?,
+                    n => {
+                        debug_assert!(n == 2);
+                        write!(f, ")")?;
+                    }
+                },
+            }
+        }
+
+        Ok(())
+    }
+}
+
 /// Identifier of a variable.
 #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct Identifier(Arc<str>);

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -280,7 +280,7 @@ impl MatchPattern {
 }
 
 /// A Simphony type.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
 #[non_exhaustive]
 pub enum Type {
     Unit,

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -3,13 +3,12 @@ use miniscript::iter::TreeLike;
 use crate::parse::{Identifier, Pattern, WitnessName};
 use crate::{named::ProgExt, ProgNode};
 
-/// A global scope is a stack of scopes.
-/// Each scope is a vector of variables.
-/// The latest scope is the last vector in the stack.
+/// Tracker of variable bindings and witness names.
 ///
-/// Our simplicity translation looks at the index
-/// of the variable from the end of stack to figure it's
-/// position in the environment.
+/// Internally there is a stack of scopes.
+/// A new scope is pushed for each (nested) block expression.
+///
+/// Bindings from higher scopes (in the stack) overwrite bindings from lower scopes.
 #[derive(Debug, Clone)]
 pub struct GlobalScope {
     variables: Vec<Vec<Pattern>>,
@@ -57,21 +56,59 @@ impl GlobalScope {
         self.witnesses.last_mut().unwrap().push(key);
     }
 
-    /// Fetches the [`ProgNode`] for a variable.
-    /// The [`ProgNode`] is a sequence of `take` and `drop` nodes
-    /// that fetches the variable from the environment.
-    /// The [`ProgNode`] is constructed by looking at the index
-    /// of the variable from the end of stack.
+    /// Get a Simplicity expression that returns the value of the given `identifier`.
     ///
-    /// # Panics
+    /// The expression is a sequence of `take` and `drop` followed by `iden`,
+    /// which extracts the seeked value from the environment.
     ///
-    /// Panics if the variable is not found.
-    pub fn get(&self, key: &Identifier) -> ProgNode {
-        // search in the vector of vectors from the end
+    /// The environment starts as the unit value.
+    ///
+    /// Each let statement updates the environment to become
+    /// the product of the assigned value (left) and of the previous environment (right).
+    ///
+    /// (Block) expressions consume the environment and return their output.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let a: u8 = 0;
+    /// let b = {
+    ///     let b: u8 = 1;
+    ///     let c: u8 = 2;
+    ///     a  // here we seek the value of `a`
+    /// };
+    /// ```
+    ///
+    /// The stack of scopes looks like this:
+    ///
+    /// `[a] [b c]`
+    ///
+    /// The environment looks like this:
+    ///
+    /// ```text
+    ///   .
+    ///  / \
+    /// C   .
+    ///    / \
+    ///   B   .
+    ///      / \
+    ///     A   1
+    /// ```
+    ///
+    /// To extract `a`, we need the expression `drop drop take iden`.
+    ///
+    /// ## Panics
+    ///
+    /// The `identifier` is undefined.
+    pub fn get(&self, identifier: &Identifier) -> ProgNode {
         let mut pos = 0;
         let mut var = None;
         for v in self.variables.iter().rev() {
-            if let Some(idx) = v.iter().rev().position(|var_name| var_name.contains(key)) {
+            if let Some(idx) = v
+                .iter()
+                .rev()
+                .position(|var_name| var_name.contains(identifier))
+            {
                 pos += idx;
                 var = Some(&v[v.len() - 1 - idx]);
                 break;
@@ -81,14 +118,14 @@ impl GlobalScope {
         }
         match var {
             Some(pattern) => {
-                let mut child = pattern.get_program(key).unwrap();
+                let mut child = pattern.get_program(identifier).unwrap();
                 child = ProgNode::take(child);
                 for _ in 0..pos {
                     child = ProgNode::drop_(child);
                 }
                 child
             }
-            None => panic!("Variable {} not found", key),
+            None => panic!("Variable {} not found", identifier),
         }
     }
 }


### PR DESCRIPTION
Enable destructing of arrays in let statements `let [a, b,c] = (1, 2, 3)`, using array patterns. Do some refactors beforehand.